### PR TITLE
Add Types & Support Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,75 @@
 [![npm version][img:npm-version]][repo:package]
 [![build status][img:repo-status]][repo:status]
 [![coverage status][img:coveralls]][ext:coveralls]
-[![conventional commits][img:commits]][ext:commits]
 
 # with-iterator
 
-A simple ECMA2015 helper function for attaching iterator factories or
-generators to arbitrary input, be it an object or primitive type.
-Key points:
+A utility for attaching iterator factories / generators to arbitrary input.
 
--   Is mutative - if passed a composite type, returns the same reference.
--   Is type aware - if passed a primitive, returns the same object type.
--   Is curried - if passed only a function, composes a new wrapper.
+-   Is mutative - when passed a composite type, returns the same reference.
+-   Is type aware - when passed a primitive, returns the same object type.
+-   Is curried - when passed a single function, composes a new wrapper.
+
+**TL;DR** [examples](#examples)
+
+## motivation
+
+The project originally served as a simple aid in understanding the mechanics of
+publishing to NPM while also an excuse to play around with generator functions,
+which I generally don't find many use-cases for in day-to-day app. development.
+For the same reason this package has limited application but I still like
+tinkering with generators on the REPL for which it has some utility.
+
+More recently I've been learning some of the more advanced TypeScript concepts
+and tried to apply them retrospectively here. They're passable but could probably
+be better - I'm not sure how to reconcile mutative behaviour for example.
+
+## install
+
+### Node
+
+```none
+> npm install with-iterator
+```
+
+```js
+const { withIterator } = require('with-iterator')
+```
+
+### Deno
+
+```typescript
+// "https://unpkg.com/with-iterator@VERSION/deno.js" VERSION >= 2.0.0
+import { withIterator } from 'https://unpkg.com/with-iterator/deno.js'
+```
 
 ## exposes
 
--   **withIterator**  
-    => ( factory: _function_, input: _any_ [, descriptor: _object_ ] ): _object_
--   **withIterator**  
-    => ( factory: _function_ ): _function_ => ( input: _any_ [, descriptor: _object_ ] ): _object_
--   **isIterable**  
-    => ( input: _any_ ): _boolean_
--   **getIterator**  
-    => ( input: _any_ ): _function_
--   **valueOf**  
-    => ( input: _any_ ): input
+> **_Note:_** _The documented types here are simplified for readability.
+> Inner types should be preserved - see [source][repo:types] for detail._
 
-The `descriptor` parameter is optional and corresponds to that of
-[`Object.defineProperty`][ext:defineproperty] - unless overridden, is
+### withIterator
+
+```typescript
+function withIterator(
+	factory: () => Generator,
+	input: any,
+	descriptor?: PropertyDescriptor
+): Iterable
+```
+
+```typescript
+function withIterator(
+	factory: () => Generator
+): (input: any, descriptor?: PropertyDescriptor) => Iterable
+```
+
+```typescript
+function withIterator(input: any): Iterable
+```
+
+The optional `descriptor` parameter corresponds to that of
+[`Object.defineProperty`][ext:defineproperty] and if not overridden, is
 set with sensible defaults:
 
 ```js
@@ -36,6 +78,24 @@ set with sensible defaults:
     configurable: true,
     enumerable: false
 }
+```
+
+### isIterable
+
+```typescript
+function isIterable(input: any): boolean
+```
+
+### getIterator
+
+```typescript
+function getIterator(input: any): unknown | () => Generator
+```
+
+### valueOf
+
+```typescript
+function valueOf(input: any): any
 ```
 
 ## examples
@@ -53,7 +113,7 @@ const {
 } = require('with-iterator')
 ```
 
-By default if not passed a factory (function), any input is assigned
+By default if not passed a factory function, any input is assigned
 an iterator that yields itself, if it isn't already iterable - else
 it is unchanged.
 
@@ -77,7 +137,8 @@ const foo = withIterator(sum, [1, 2, 3, 4, 5])
 Array.from(foo) // [ 1, 3, 6, 10, 15 ]
 ```
 
-Can compose new helpers and works with primitives.
+When only passed a factory, will compose a new helper. This
+examples also demonstrates the use of primitive input.
 
 ```js
 const hex = ['123456', 'cc9933', 'fedcba']
@@ -94,7 +155,7 @@ hex.map(rgb).forEach(code => {
 // hex: fedcba - rgb: (254,220,186)
 ```
 
-Can work with prototypes.
+Setting an iterator on a class prototype.
 
 ```js
 class Digits extends Number {}
@@ -106,7 +167,7 @@ const digits = new Digits(54321)
 Array.from(digits) // [5, 4, 3, 2, 1]
 ```
 
-Resolve boxed primitives.
+Resolving boxed primitives.
 
 ```js
 const nul = withIterator(null)
@@ -122,10 +183,9 @@ console.log(
 [repo:status]: https://travis-ci.org/mylesj/with-iterator
 [repo:package]: https://www.npmjs.com/package/with-iterator
 [repo:examples]: https://runkit.com/mylesj/with-iterator/1.2.0
+[repo:types]: https://github.com/mylesj/with-iterator/blob/master/types.d.ts
 [ext:defineproperty]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
-[ext:commits]: https://conventionalcommits.org
 [ext:coveralls]: https://coveralls.io/github/mylesj/with-iterator?branch=master
 [img:repo-status]: https://travis-ci.org/mylesj/with-iterator.svg?branch=master
 [img:npm-version]: https://badgen.net/npm/v/with-iterator
-[img:commits]: https://badgen.net/badge/conventional%20commits/1.0.0/yellow
 [img:coveralls]: https://coveralls.io/repos/github/mylesj/with-iterator/badge.svg?branch=master

--- a/deno.js
+++ b/deno.js
@@ -1,0 +1,2 @@
+/// <reference types="./types.d.ts" />
+export * from './dist/index.esm.js'

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
 	"bugs": "https://github.com/mylesj/with-iterator/issues",
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.esm.js",
+	"types": "types.d.ts",
 	"files": [
-		"dist/"
+		"dist/",
+		"types.d.ts"
 	],
 	"license": "ISC",
 	"scripts": {
@@ -33,7 +35,7 @@
 		}
 	},
 	"lint-staged": {
-		"**/*.{js,json,md}": [
+		"**/*.{ts,js,json,md}": [
 			"prettier --write",
 			"git add"
 		]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"iterator",
 		"generator",
 		"functional",
-		"agnostic"
+		"agnostic",
+		"deno"
 	],
 	"repository": "github:mylesj/with-iterator",
 	"bugs": "https://github.com/mylesj/with-iterator/issues",
@@ -19,14 +20,16 @@
 	"types": "types.d.ts",
 	"files": [
 		"dist/",
-		"types.d.ts"
+		"types.d.ts",
+		"deno.js"
 	],
 	"license": "ISC",
 	"scripts": {
 		"prebuild": "rimraf dist",
 		"build": "rollup -c",
 		"test": "jest -c jest.config.json",
-		"prerelease": "npm run build && npm run test",
+		"test-deno": "deno test ./test/_deno-{dist,src}.js",
+		"prerelease": "npm run build && npm run test && npm run test-deno",
 		"release": "standard-version --commit-all"
 	},
 	"husky": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { withIterator } from './with-iterator'
-export { isIterable, getIterator, valueOf } from './utils'
+export { withIterator } from './with-iterator.js'
+export { isIterable, getIterator, valueOf } from './utils.js'

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import {
 	isFunction,
 	Undefined,
 	Null
-} from './types'
+} from './types.js'
 
 export const isIterable = thing => isFunction(Object(thing)[Symbol.iterator])
 

--- a/src/with-iterator.js
+++ b/src/with-iterator.js
@@ -1,5 +1,5 @@
-import { isIterable, boxed } from './utils'
-import { isUndefined, isFunction, Empty } from './types'
+import { isIterable, boxed } from './utils.js'
+import { isUndefined, isFunction, Empty } from './types.js'
 
 const assignIterator = (iterator, thing, descriptor) => {
 	const isIterator = isFunction(iterator)

--- a/test/_deno-dist.js
+++ b/test/_deno-dist.js
@@ -1,0 +1,25 @@
+// verify deno import works with bundled dist
+
+import { assert, assertEquals } from 'https://deno.land/std/testing/asserts.ts'
+
+import { withIterator, isIterable, getIterator, valueOf } from '../deno.js'
+
+Deno.test('DIST: all imports have extensions', () => {
+	// listed in case of "unused import" linting
+	// and / or unintended dead-code elimination
+	withIterator
+	isIterable
+	getIterator
+	valueOf
+
+	assert(true)
+})
+
+Deno.test('DIST: basic input / output', () => {
+	const it = function*() {
+		yield* [1, 2, 3]
+	}
+	const expected = [1, 2, 3]
+	const actual = Array.from(withIterator(it, null))
+	assertEquals(actual, expected)
+})

--- a/test/_deno-src.js
+++ b/test/_deno-src.js
@@ -1,0 +1,25 @@
+// verify deno import works with direct source files
+
+import { assert, assertEquals } from 'https://deno.land/std/testing/asserts.ts'
+
+import { withIterator, isIterable, getIterator, valueOf } from '../src/index.js'
+
+Deno.test('SRC: all imports have extensions', () => {
+	// listed in case of "unused import" linting
+	// and / or unintended dead-code elimination
+	withIterator
+	isIterable
+	getIterator
+	valueOf
+
+	assert(true)
+})
+
+Deno.test('SRC: basic input / output', () => {
+	const it = function*() {
+		yield* [1, 2, 3]
+	}
+	const expected = [1, 2, 3]
+	const actual = Array.from(withIterator(it, null))
+	assertEquals(actual, expected)
+})

--- a/test/withIterator.test.js
+++ b/test/withIterator.test.js
@@ -110,15 +110,16 @@ describe('withIterator', () => {
 			})
 
 			describe('if an iterator exists on the prototype', () => {
-				describe('should return the primitive value', () =>
+				describe('should return the primitive value', () => {
 					test('String', () =>
 						expect(withIterator('str') instanceof String).toBe(
 							false
-						)))
+						))
+				})
 			})
 
-			describe('has an iterator returning scalar values', () =>
-				[1, true, 'str', Symbol()].forEach(value =>
+			describe('has an iterator returning scalar values', () => {
+				;[1, true, 'str', Symbol()].forEach(value =>
 					test(Object(value).constructor.name, () => {
 						const item = withIterator(value)
 						expect(Array.from(item)).toEqual(
@@ -127,7 +128,8 @@ describe('withIterator', () => {
 								: expect.arrayContaining([value])
 						)
 					})
-				))
+				)
+			})
 		})
 	})
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,57 @@
+export interface Empty {
+	toString(): string
+}
+
+export interface Undefined extends Empty {
+	valueOf(): undefined
+}
+
+export interface Null extends Empty {
+	valueOf(): null
+}
+
+export type Boxed<T> = T extends undefined
+	? Undefined
+	: T extends null
+	? Null
+	: T extends string
+	? String
+	: T extends number
+	? Number
+	: T extends boolean
+	? Boolean
+	: T
+
+export declare function valueOf<T>(
+	input: T
+): T extends Undefined
+	? undefined
+	: T extends Null
+	? null
+	: T extends String
+	? string
+	: T extends Number
+	? number
+	: T extends Boolean
+	? boolean
+	: T
+
+export declare function isIterable<T>(
+	input: T
+): T extends Iterable<unknown> ? true : boolean
+
+export declare function getIterator<T>(
+	input: T
+): T extends Iterable<infer U> ? () => Generator<U> : unknown
+
+export declare function withIterator<T = unknown, U = unknown>(
+	factory: () => Generator<T>,
+	input: U,
+	descriptor?: PropertyDescriptor
+): Boxed<U> & Iterable<T>
+
+export declare function withIterator<T = unknown, U = unknown>(
+	input: U extends Function ? () => Generator<T> : U
+): U extends Function
+	? <V>(input: V, descriptor?: PropertyDescriptor) => Boxed<V> & Iterable<T>
+	: Boxed<U> & Iterable<U>


### PR DESCRIPTION
Not sure how to reconcile mutative behaviour but it's workable in this case as the function/s return the original object reference anyway. For the boxed types to work properly `strictNullChecks` needs to be enabled - though I've noticed with this switched on, some of the type-resolutions get lost and revert to just `any` - I'm not sure if this is just VSCode or an issue with importing local libs. Will need to test it again once published.